### PR TITLE
Simulate projectile and write canvas to file

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,12 +1,12 @@
 use crate::color::Color;
 use std::vec::Vec;
 
-struct Canvas {
+pub struct Canvas {
     pixels: Vec<Vec<Color>>,
 }
 
 impl Canvas {
-    fn new(width: usize, height: usize) -> Self {
+    pub fn new(width: usize, height: usize) -> Self {
         Canvas {
             pixels: vec![
                 vec![
@@ -22,11 +22,11 @@ impl Canvas {
         }
     }
 
-    fn width(&self) -> usize {
+    pub fn width(&self) -> usize {
         self.pixels.len()
     }
 
-    fn height(&self) -> usize {
+    pub fn height(&self) -> usize {
         if self.pixels.is_empty() {
             0
         } else {
@@ -34,11 +34,11 @@ impl Canvas {
         }
     }
 
-    fn get_pixel(&self, x: usize, y: usize) -> Color {
+    pub fn get_pixel(&self, x: usize, y: usize) -> Color {
         self.pixels[x][y]
     }
 
-    fn set_pixel(&mut self, x: usize, y: usize, c: Color) {
+    pub fn set_pixel(&mut self, x: usize, y: usize, c: Color) {
         self.pixels[x][y] = c
     }
 
@@ -64,7 +64,7 @@ impl Canvas {
         result
     }
 
-    fn write_ppm(&self, file: String) {
+    pub fn write_ppm(&self, file: String) {
         use std::fs;
         let data = self.to_ppm();
         fs::write(file, data).expect("Unable to write file");

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -1,14 +1,24 @@
-use std::vec::Vec;
 use crate::color::Color;
+use std::vec::Vec;
 
 struct Canvas {
-    pixels: Vec<Vec<Color>>
+    pixels: Vec<Vec<Color>>,
 }
 
 impl Canvas {
     fn new(width: usize, height: usize) -> Self {
         Canvas {
-            pixels: vec![vec![Color { r: 0.0, g: 0.0, b: 0.0 }; height]; width]
+            pixels: vec![
+                vec![
+                    Color {
+                        r: 0.0,
+                        g: 0.0,
+                        b: 0.0
+                    };
+                    height
+                ];
+                width
+            ],
         }
     }
 
@@ -17,7 +27,11 @@ impl Canvas {
     }
 
     fn height(&self) -> usize {
-        if self.pixels.is_empty() { 0 } else { self.pixels[0].len() }
+        if self.pixels.is_empty() {
+            0
+        } else {
+            self.pixels[0].len()
+        }
     }
 
     fn get_pixel(&self, x: usize, y: usize) -> Color {
@@ -32,8 +46,8 @@ impl Canvas {
 #[cfg(test)]
 mod tests {
     use crate::canvas::Canvas;
-    use crate::color::Color;
     use crate::color::test_utils::assert_color_eq;
+    use crate::color::Color;
 
     #[test]
     fn create_canvas() {
@@ -42,7 +56,14 @@ mod tests {
         assert_eq!(20, canvas.height());
         for x in 0..canvas.width() {
             for y in 0..canvas.height() {
-                assert_color_eq(Color { r: 0.0, g: 0.0, b: 0.0 }, canvas.get_pixel(x, y));
+                assert_color_eq(
+                    Color {
+                        r: 0.0,
+                        g: 0.0,
+                        b: 0.0,
+                    },
+                    canvas.get_pixel(x, y),
+                );
             }
         }
     }
@@ -50,7 +71,11 @@ mod tests {
     #[test]
     fn writing_pixels_to_canvas() {
         let mut canvas = Canvas::new(10, 20);
-        let color = Color { r: 1.0, g: 0.0, b: 0.0 };
+        let color = Color {
+            r: 1.0,
+            g: 0.0,
+            b: 0.0,
+        };
 
         canvas.set_pixel(2, 3, color);
 

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -41,6 +41,48 @@ impl Canvas {
     fn set_pixel(&mut self, x: usize, y: usize, c: Color) {
         self.pixels[x][y] = c
     }
+
+    fn to_ppm(&self) -> String {
+        let mut result = format!(
+            "P3\n{width} {height}\n255\n",
+            width = self.width(),
+            height = self.height(),
+        );
+        for y in 0..self.height() {
+            let mut row_str = vec!["0".to_string(); self.width()];
+            for x in 0..self.width() {
+                let p = self.get_pixel(x, y);
+                let r = self.convert(p.r);
+                let g = self.convert(p.g);
+                let b = self.convert(p.b);
+                row_str[x] = format!("{} {} {}", r, g, b);
+            }
+            result.push_str(&row_str.join(" "));
+            result.push_str("\n");
+        }
+
+        result
+    }
+
+    fn write_ppm(&self, file: String) {
+        use std::fs;
+        let data = self.to_ppm();
+        fs::write(file, data).expect("Unable to write file");
+    }
+
+    fn convert(&self, val: f64) -> u8 {
+        self.clamp(val * 255., 0., 255.).round() as u8
+    }
+
+    fn clamp(&self, val: f64, min: f64, max: f64) -> f64 {
+        if val < min {
+            min
+        } else if val > max {
+            max
+        } else {
+            val
+        }
+    }
 }
 
 #[cfg(test)]
@@ -80,5 +122,39 @@ mod tests {
         canvas.set_pixel(2, 3, color);
 
         assert_color_eq(color, canvas.get_pixel(2, 3));
+    }
+
+    #[test]
+    fn to_ppm_constructs_ppm_header() {
+        let canvas = Canvas::new(5, 3);
+        let ppm_str = canvas.to_ppm();
+        let header_lines: Vec<&str> = ppm_str.lines().take(3).collect();
+        assert_eq!("P3", header_lines[0]);
+        assert_eq!("5 3", header_lines[1]);
+        assert_eq!("255", header_lines[2]);
+    }
+
+    #[test]
+    fn to_ppm_constructs_ppm_pixel_data() {
+        let mut canvas = Canvas::new(5, 3);
+        let c1 = Color::new(1.5, 0.0, 0.0);
+        let c2 = Color::new(0.0, 0.5, 0.0);
+        let c3 = Color::new(-0.5, 0.0, 1.0);
+        canvas.set_pixel(0, 0, c1);
+        canvas.set_pixel(2, 1, c2);
+        canvas.set_pixel(4, 2, c3);
+
+        let ppm_str = canvas.to_ppm();
+        let pixel_data: Vec<&str> = ppm_str.lines().skip(3).take(3).collect();
+        assert_eq!("255 0 0 0 0 0 0 0 0 0 0 0 0 0 0", pixel_data[0]);
+        assert_eq!("0 0 0 0 0 0 0 128 0 0 0 0 0 0 0", pixel_data[1]);
+        assert_eq!("0 0 0 0 0 0 0 0 0 0 0 0 0 0 255", pixel_data[2]);
+    }
+
+    #[test]
+    fn to_ppm_adds_terminating_newline() {
+        let canvas = Canvas::new(5, 3);
+        let ppm_str = canvas.to_ppm();
+        assert_eq!('\n', ppm_str.chars().last().unwrap());
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -1,4 +1,4 @@
-use std::ops::{Add, Sub, Mul};
+use std::ops::{Add, Mul, Sub};
 
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub struct Color {
@@ -68,8 +68,8 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use crate::color::Color;
     use crate::color::test_utils::assert_color_eq;
+    use crate::color::Color;
 
     #[test]
     fn create_color() {
@@ -85,28 +85,84 @@ mod tests {
 
     #[test]
     fn color_ops_addition() {
-        let c1 = Color { r: 0.9, g: 0.6, b: 0.75 };
-        let c2 = Color { r: 0.7, g: 0.1, b: 0.25 };
-        assert_color_eq(Color { r: 1.6, g: 0.7, b: 1.0 }, c1 + c2);
+        let c1 = Color {
+            r: 0.9,
+            g: 0.6,
+            b: 0.75,
+        };
+        let c2 = Color {
+            r: 0.7,
+            g: 0.1,
+            b: 0.25,
+        };
+        assert_color_eq(
+            Color {
+                r: 1.6,
+                g: 0.7,
+                b: 1.0,
+            },
+            c1 + c2,
+        );
     }
 
     #[test]
     fn color_ops_subtraction() {
-        let c1 = Color { r: 0.9, g: 0.6, b: 0.75 };
-        let c2 = Color { r: 0.7, g: 0.1, b: 0.25 };
-        assert_color_eq(Color { r: 0.2, g: 0.5, b: 0.5 }, c1 - c2);
+        let c1 = Color {
+            r: 0.9,
+            g: 0.6,
+            b: 0.75,
+        };
+        let c2 = Color {
+            r: 0.7,
+            g: 0.1,
+            b: 0.25,
+        };
+        assert_color_eq(
+            Color {
+                r: 0.2,
+                g: 0.5,
+                b: 0.5,
+            },
+            c1 - c2,
+        );
     }
 
     #[test]
     fn color_ops_multiply_colors() {
-        let c1 = Color { r: 1.0, g: 0.2, b: 0.4 };
-        let c2 = Color { r: 0.9, g: 1.0, b: 0.1 };
-        assert_color_eq(Color { r: 0.9, g: 0.2, b: 0.04 }, c1 * c2);
+        let c1 = Color {
+            r: 1.0,
+            g: 0.2,
+            b: 0.4,
+        };
+        let c2 = Color {
+            r: 0.9,
+            g: 1.0,
+            b: 0.1,
+        };
+        assert_color_eq(
+            Color {
+                r: 0.9,
+                g: 0.2,
+                b: 0.04,
+            },
+            c1 * c2,
+        );
     }
 
     #[test]
     fn color_ops_multiply_by_scalar() {
-        let c = Color { r: 0.2, g: 0.3, b: 0.4 };
-        assert_color_eq(Color { r: 0.4, g: 0.6, b: 0.8 }, c * 2.0);
+        let c = Color {
+            r: 0.2,
+            g: 0.3,
+            b: 0.4,
+        };
+        assert_color_eq(
+            Color {
+                r: 0.4,
+                g: 0.6,
+                b: 0.8,
+            },
+            c * 2.0,
+        );
     }
 }

--- a/src/color.rs
+++ b/src/color.rs
@@ -7,6 +7,12 @@ pub struct Color {
     pub b: f64,
 }
 
+impl Color {
+    pub fn new(r: f64, g: f64, b: f64) -> Self {
+        Color { r, g, b }
+    }
+}
+
 impl Add for Color {
     type Output = Self;
 
@@ -73,11 +79,7 @@ mod tests {
 
     #[test]
     fn create_color() {
-        let c = Color {
-            r: -0.5,
-            g: 0.4,
-            b: 1.7,
-        };
+        let c = Color::new(-0.5, 0.4, 1.7);
         assert_eq!(-0.5, c.r);
         assert_eq!(0.4, c.g);
         assert_eq!(1.7, c.b);
@@ -85,84 +87,28 @@ mod tests {
 
     #[test]
     fn color_ops_addition() {
-        let c1 = Color {
-            r: 0.9,
-            g: 0.6,
-            b: 0.75,
-        };
-        let c2 = Color {
-            r: 0.7,
-            g: 0.1,
-            b: 0.25,
-        };
-        assert_color_eq(
-            Color {
-                r: 1.6,
-                g: 0.7,
-                b: 1.0,
-            },
-            c1 + c2,
-        );
+        let c1 = Color::new(0.9, 0.6, 0.75);
+        let c2 = Color::new(0.7, 0.1, 0.25);
+        assert_color_eq(Color::new(1.6, 0.7, 1.0), c1 + c2);
     }
 
     #[test]
     fn color_ops_subtraction() {
-        let c1 = Color {
-            r: 0.9,
-            g: 0.6,
-            b: 0.75,
-        };
-        let c2 = Color {
-            r: 0.7,
-            g: 0.1,
-            b: 0.25,
-        };
-        assert_color_eq(
-            Color {
-                r: 0.2,
-                g: 0.5,
-                b: 0.5,
-            },
-            c1 - c2,
-        );
+        let c1 = Color::new(0.9, 0.6, 0.75);
+        let c2 = Color::new(0.7, 0.1, 0.25);
+        assert_color_eq(Color::new(0.2, 0.5, 0.5), c1 - c2);
     }
 
     #[test]
     fn color_ops_multiply_colors() {
-        let c1 = Color {
-            r: 1.0,
-            g: 0.2,
-            b: 0.4,
-        };
-        let c2 = Color {
-            r: 0.9,
-            g: 1.0,
-            b: 0.1,
-        };
-        assert_color_eq(
-            Color {
-                r: 0.9,
-                g: 0.2,
-                b: 0.04,
-            },
-            c1 * c2,
-        );
+        let c1 = Color::new(1.0, 0.2, 0.4);
+        let c2 = Color::new(0.9, 1.0, 0.1);
+        assert_color_eq(Color::new(0.9, 0.2, 0.04), c1 * c2);
     }
 
     #[test]
     fn color_ops_multiply_by_scalar() {
-        let c = Color {
-            r: 0.2,
-            g: 0.3,
-            b: 0.4,
-        };
-        assert_color_eq(
-            Color {
-                r: 0.4,
-                g: 0.6,
-                b: 0.8,
-            },
-            c * 2.0,
-        );
+        let c = Color::new(0.2, 0.3, 0.4);
+        assert_color_eq(Color::new(0.4, 0.6, 0.8), c * 2.0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,38 +23,29 @@ fn tick(env: &Environment, proj: Projectile) -> Projectile {
 }
 
 fn main() {
-    println!("Hello, world!");
-    let t = Tuple {
-        x: 1.0,
-        y: 1.0,
-        z: 1.0,
-        w: 1.0,
-    };
-    println!("A tuple: {:?}", t);
-    println!("Is point: {}, is vector: {}", t.is_point(), t.is_vector());
-
-    let t2 = Tuple {
-        x: 2.0,
-        w: 2.0,
-        ..t
-    };
-    println!("A tuple: {:?}", t2);
-    println!("Is point: {}, is vector: {}", t2.is_point(), t2.is_vector());
-
     let mut proj = Projectile {
         pos: tuple::point(0.0, 1.0, 0.0),
-        vel: tuple::vector(1.0, 1.0, 0.0).normalize(),
+        vel: tuple::vector(1.0, 1.8, 0.0).normalize() * 11.25,
     };
     let env = Environment {
         gravity: tuple::vector(0.0, -0.1, 0.0),
         wind: tuple::vector(-0.01, 0.0, 0.0),
     };
+    let mut canvas = canvas::Canvas::new(900, 560);
     let mut ticks = 0;
+
+    let red = color::Color::new(1.0, 0.0, 0.0);
 
     while proj.pos.y > 0.0 {
         println!("Projectile pos: {:?}", proj.pos);
+        canvas.set_pixel(
+            proj.pos.x.round() as usize,
+            canvas.height() - proj.pos.y.round() as usize,
+            red,
+        );
         proj = tick(&env, proj);
         ticks += 1;
     }
     println!("Ticks: {}", ticks);
+    canvas.write_ppm("projectile.ppm".to_string());
 }


### PR DESCRIPTION
Works in Ubuntu 18.04 without splitting long lines in ppm files so I have not implemented that yet.