### PR TITLE
Rework of matrix implementation

### DIFF
--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,4 +1,5 @@
 use std::ops::{Add, Div, Mul, Neg, Sub};
+use std::vec::Vec;
 
 #[derive(PartialEq, Debug, Copy, Clone)]
 pub struct Tuple {
@@ -13,7 +14,7 @@ impl Tuple {
         Tuple { x, y, z, w }
     }
 
-    pub fn from_array(a: [f64; 4]) -> Self {
+    pub fn from_vec(a: Vec<f64>) -> Self {
         Tuple {
             x: a[0],
             y: a[1],


### PR DESCRIPTION
New underlying data type for matrix implementation. It now uses vector instead of array. Had some trouble with the macro solution when I started to do work with inverting matrices. Hopefully it will be easier with this implementation. However this implementation is not that safe since it will crash at runtime when doing illegal operations, such as multiplying a 4x4 matrix with a 3x3 matrix.